### PR TITLE
#20/detail-api

### DIFF
--- a/applications/khj-teacher-application/src/apis/data.ts
+++ b/applications/khj-teacher-application/src/apis/data.ts
@@ -13,9 +13,25 @@ export interface UserInfoResponse {
   flame: number;
 }
 
+interface GrassItem {
+  date: string;
+  value: number;
+}
+
+export interface UserGrassResponse {
+  grass: GrassItem[];
+}
+
 export const getUserInfo = async (id: number) => {
   const response = await api.get<UserInfoResponse>(
     `/api/v2/data/student/${id}`,
+  );
+  return response.data;
+};
+
+export const getUserGrass = async (id: number, period: number = 7) => {
+  const response = await api.get<UserGrassResponse>(
+    `/api/v2/data/student/${id}/grass/?period=${period}`,
   );
   return response.data;
 };

--- a/applications/khj-teacher-application/src/apis/data.ts
+++ b/applications/khj-teacher-application/src/apis/data.ts
@@ -1,0 +1,21 @@
+import { api } from "./axios";
+
+export interface UserInfoResponse {
+  id: number;
+  studentNumber: number;
+  name: string;
+  bojId: string;
+  tier: string;
+  totalSolved: number;
+  accuracyRate: number;
+  streak: number;
+  maxStreak: number;
+  flame: number;
+}
+
+export const getUserInfo = async (id: number) => {
+  const response = await api.get<UserInfoResponse>(
+    `/api/v2/data/student/${id}`,
+  );
+  return response.data;
+};

--- a/applications/khj-teacher-application/src/apis/data.ts
+++ b/applications/khj-teacher-application/src/apis/data.ts
@@ -7,6 +7,7 @@ export interface UserInfoResponse {
   bojId: string;
   tier: string;
   totalSolved: number;
+  todaySolved?: number;
   accuracyRate: number;
   streak: number;
   maxStreak: number;

--- a/applications/khj-teacher-application/src/apis/data.ts
+++ b/applications/khj-teacher-application/src/apis/data.ts
@@ -13,7 +13,7 @@ export interface UserInfoResponse {
   flame: number;
 }
 
-interface GrassItem {
+export interface GrassItem {
   date: string;
   value: number;
 }

--- a/applications/khj-teacher-application/src/pages/Detail.tsx
+++ b/applications/khj-teacher-application/src/pages/Detail.tsx
@@ -2,11 +2,17 @@ import { UserInfo } from "@khj/user-interfaces";
 import styled from "@emotion/styled";
 import { useParams } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
-import { getUserInfo, type UserInfoResponse } from "../apis/data";
+import {
+  getUserGrass,
+  getUserInfo,
+  type UserGrassResponse,
+  type UserInfoResponse,
+} from "../apis/data";
 import { useState, useEffect } from "react";
 
 export default function Detail() {
   const [userInfo, setUserInfo] = useState<UserInfoResponse | null>(null);
+  const [userGrass, setUserGrass] = useState<UserGrassResponse["grass"]>([]);
 
   const { id } = useParams();
 
@@ -21,11 +27,23 @@ export default function Detail() {
     },
   });
 
+  const { mutate: getUserGrassMutate } = useMutation({
+    mutationFn: (id: number) => getUserGrass(id, 7),
+    onSuccess: (data: UserGrassResponse) => {
+      setUserGrass(data.grass ?? []);
+    },
+    onError: (error) => {
+      console.error("유저 grass 조회 실패:", error);
+      setUserGrass([]);
+    },
+  });
+
   useEffect(() => {
     if (id) {
       getUserInfoMutate(Number(id));
+      getUserGrassMutate(Number(id));
     }
-  }, [id, getUserInfoMutate]);
+  }, [id, getUserGrassMutate, getUserInfoMutate]);
 
   return (
     <Wrapper>
@@ -40,6 +58,7 @@ export default function Detail() {
         streak={userInfo?.streak || 0}
         maxStreak={userInfo?.maxStreak || 0}
         flame={userInfo?.flame || 0}
+        grass={userGrass}
       />
     </Wrapper>
   );

--- a/applications/khj-teacher-application/src/pages/Detail.tsx
+++ b/applications/khj-teacher-application/src/pages/Detail.tsx
@@ -12,15 +12,23 @@ import {
 export default function Detail() {
   const { id } = useParams();
   const numericId = Number(id);
-  const isValidId = Number.isFinite(numericId);
+  const isValidId = Number.isInteger(numericId) && numericId > 0;
 
-  const { data: userInfo } = useQuery<UserInfoResponse>({
+  const {
+    data: userInfo,
+    isLoading: isUserInfoLoading,
+    isError: isUserInfoError,
+  } = useQuery<UserInfoResponse>({
     queryKey: ["userInfo", id],
     queryFn: () => getUserInfo(numericId),
     enabled: isValidId,
   });
 
-  const { data: userGrassResponse } = useQuery({
+  const {
+    data: userGrassResponse,
+    isLoading: isUserGrassLoading,
+    isError: isUserGrassError,
+  } = useQuery({
     queryKey: ["userGrass", id, 7],
     queryFn: () => getUserGrass(numericId, 7),
     enabled: isValidId,
@@ -28,19 +36,29 @@ export default function Detail() {
 
   const userGrass: GrassItem[] = userGrassResponse?.grass ?? [];
 
+  if (!isValidId) {
+    return <Wrapper>유효하지 않은 ID입니다.</Wrapper>;
+  }
+
+  if (isUserInfoLoading || isUserGrassLoading) {
+    return <Wrapper>로딩 중...</Wrapper>;
+  }
+
+  if (isUserInfoError || isUserGrassError) {
+    return <Wrapper>데이터를 불러오는 중 오류가 발생했습니다.</Wrapper>;
+  }
+
   return (
     <Wrapper>
       <UserInfo
-        id={numericId}
-        studentNumber={userInfo?.studentNumber || 0}
-        name={userInfo?.name || ""}
-        bojId={userInfo?.bojId || ""}
-        tier={userInfo?.tier || ""}
-        totalSolved={userInfo?.totalSolved || 0}
-        accuracyRate={userInfo?.accuracyRate || 0}
-        streak={userInfo?.streak || 0}
-        maxStreak={userInfo?.maxStreak || 0}
-        flame={userInfo?.flame || 0}
+        studentNumber={userInfo?.studentNumber ?? 0}
+        name={userInfo?.name ?? ""}
+        bojId={userInfo?.bojId ?? ""}
+        tier={userInfo?.tier ?? ""}
+        totalSolved={userInfo?.totalSolved ?? 0}
+        todaySolved={userInfo?.todaySolved ?? 0}
+        accuracyRate={userInfo?.accuracyRate ?? 0}
+        streak={userInfo?.streak ?? 0}
         grass={userGrass}
       />
     </Wrapper>

--- a/applications/khj-teacher-application/src/pages/Detail.tsx
+++ b/applications/khj-teacher-application/src/pages/Detail.tsx
@@ -1,54 +1,37 @@
 import { UserInfo } from "@khj/user-interfaces";
 import styled from "@emotion/styled";
 import { useParams } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   getUserGrass,
   getUserInfo,
-  type UserGrassResponse,
+  type GrassItem,
   type UserInfoResponse,
 } from "../apis/data";
-import { useState, useEffect } from "react";
 
 export default function Detail() {
-  const [userInfo, setUserInfo] = useState<UserInfoResponse | null>(null);
-  const [userGrass, setUserGrass] = useState<UserGrassResponse["grass"]>([]);
-
   const { id } = useParams();
+  const numericId = Number(id);
+  const isValidId = Number.isFinite(numericId);
 
-  const { mutate: getUserInfoMutate } = useMutation({
-    mutationFn: (id: number) => getUserInfo(id),
-    onSuccess: (data: UserInfoResponse) => {
-      console.log("유저 정보 조회 성공:", data);
-      setUserInfo(data);
-    },
-    onError: (error) => {
-      console.error("유저 정보 조회 실패:", error);
-    },
+  const { data: userInfo } = useQuery<UserInfoResponse>({
+    queryKey: ["userInfo", id],
+    queryFn: () => getUserInfo(numericId),
+    enabled: isValidId,
   });
 
-  const { mutate: getUserGrassMutate } = useMutation({
-    mutationFn: (id: number) => getUserGrass(id, 7),
-    onSuccess: (data: UserGrassResponse) => {
-      setUserGrass(data.grass ?? []);
-    },
-    onError: (error) => {
-      console.error("유저 grass 조회 실패:", error);
-      setUserGrass([]);
-    },
+  const { data: userGrassResponse } = useQuery({
+    queryKey: ["userGrass", id, 7],
+    queryFn: () => getUserGrass(numericId, 7),
+    enabled: isValidId,
   });
 
-  useEffect(() => {
-    if (id) {
-      getUserInfoMutate(Number(id));
-      getUserGrassMutate(Number(id));
-    }
-  }, [id, getUserGrassMutate, getUserInfoMutate]);
+  const userGrass: GrassItem[] = userGrassResponse?.grass ?? [];
 
   return (
     <Wrapper>
       <UserInfo
-        id={Number(id)}
+        id={numericId}
         studentNumber={userInfo?.studentNumber || 0}
         name={userInfo?.name || ""}
         bojId={userInfo?.bojId || ""}

--- a/applications/khj-teacher-application/src/pages/Detail.tsx
+++ b/applications/khj-teacher-application/src/pages/Detail.tsx
@@ -1,10 +1,46 @@
 import { UserInfo } from "@khj/user-interfaces";
 import styled from "@emotion/styled";
+import { useParams } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { getUserInfo, type UserInfoResponse } from "../apis/data";
+import { useState, useEffect } from "react";
 
 export default function Detail() {
+  const [userInfo, setUserInfo] = useState<UserInfoResponse | null>(null);
+
+  const { id } = useParams();
+
+  const { mutate: getUserInfoMutate } = useMutation({
+    mutationFn: (id: number) => getUserInfo(id),
+    onSuccess: (data: UserInfoResponse) => {
+      console.log("유저 정보 조회 성공:", data);
+      setUserInfo(data);
+    },
+    onError: (error) => {
+      console.error("유저 정보 조회 실패:", error);
+    },
+  });
+
+  useEffect(() => {
+    if (id) {
+      getUserInfoMutate(Number(id));
+    }
+  }, [id, getUserInfoMutate]);
+
   return (
     <Wrapper>
-      <UserInfo />
+      <UserInfo
+        id={Number(id)}
+        studentNumber={userInfo?.studentNumber || 0}
+        name={userInfo?.name || ""}
+        bojId={userInfo?.bojId || ""}
+        tier={userInfo?.tier || ""}
+        totalSolved={userInfo?.totalSolved || 0}
+        accuracyRate={userInfo?.accuracyRate || 0}
+        streak={userInfo?.streak || 0}
+        maxStreak={userInfo?.maxStreak || 0}
+        flame={userInfo?.flame || 0}
+      />
     </Wrapper>
   );
 }

--- a/applications/khj-teacher-application/src/routes.tsx
+++ b/applications/khj-teacher-application/src/routes.tsx
@@ -42,7 +42,7 @@ export const router = createBrowserRouter([
         element: <List />,
       },
       {
-        path: "detail",
+        path: "detail/:id",
         element: <Detail />,
       },
       {

--- a/modules/khj-user-interfaces/src/UserInfo.tsx
+++ b/modules/khj-user-interfaces/src/UserInfo.tsx
@@ -24,7 +24,31 @@ ChartJS.register(
   Legend,
 );
 
-export default function UserInfo() {
+interface UserInfoProps {
+  id: number;
+  studentNumber: number;
+  name: string;
+  bojId: string;
+  tier: string;
+  totalSolved: number;
+  accuracyRate: number;
+  streak: number;
+  maxStreak: number;
+  flame: number;
+}
+
+export default function UserInfo({
+  // id,
+  studentNumber,
+  name,
+  bojId,
+  tier,
+  totalSolved,
+  accuracyRate,
+  streak,
+  // maxStreak,
+  // flame,
+}: UserInfoProps) {
   const WeekDates = useMemo(() => {
     const curr = new Date();
     const first = curr.getDate() - curr.getDay();
@@ -124,8 +148,10 @@ export default function UserInfo() {
   return (
     <Wrapper>
       <ChartWrapper>
-        <Name>1310 전재준</Name>
-        <Day>D+ 9</Day>
+        <Name>
+          {studentNumber || 0} {name || "이름 없음"}
+        </Name>
+        <Day>D+ {streak || 0}</Day>
 
         <ChartInnerContainer>
           <Line data={chartData} options={chartOptions} />
@@ -140,21 +166,21 @@ export default function UserInfo() {
       <SidebarWrapper>
         <Box>
           <p>백준 ID</p>
-          <span>jaejun090210</span>
+          <span>{bojId || "ID 없음"}</span>
         </Box>
         <Box>
           <p>Solved.ac 랭크</p>
-          <span>다이아2</span>
+          <span>{tier || "랭크 없음"}</span>
         </Box>
         <TotalBox>
           <p>Total</p>
-          <span>1000개</span>
+          <span>{totalSolved || 0}</span>
           <p>Today</p>
-          <span>10개</span>
+          <span>{totalSolved || 0}</span>
         </TotalBox>
         <Box>
           <p>정답률</p>
-          <span>99%</span>
+          <span>{accuracyRate || 0}%</span>
         </Box>
         <ComebackBox>
           <ComebackList to="/list">리스트로 돌아가기</ComebackList>

--- a/modules/khj-user-interfaces/src/UserInfo.tsx
+++ b/modules/khj-user-interfaces/src/UserInfo.tsx
@@ -35,10 +35,13 @@ interface UserInfoProps {
   streak: number;
   maxStreak: number;
   flame: number;
+  grass: {
+    date: string;
+    value: number;
+  }[];
 }
 
 export default function UserInfo({
-  // id,
   studentNumber,
   name,
   bojId,
@@ -46,22 +49,43 @@ export default function UserInfo({
   totalSolved,
   accuracyRate,
   streak,
-  // maxStreak,
-  // flame,
+  grass,
 }: UserInfoProps) {
-  const WeekDates = useMemo(() => {
+  const fallbackWeekDates = useMemo(() => {
     const curr = new Date();
-    const first = curr.getDate() - curr.getDay();
 
     return Array.from({ length: 7 }, (_, i) => {
-      const day = new Date(curr.setDate(first + i));
+      const day = new Date(
+        curr.getFullYear(),
+        curr.getMonth(),
+        curr.getDate() - curr.getDay() + i,
+      );
       return `${(day.getMonth() + 1).toString().padStart(2, "0")}/${day.getDate().toString().padStart(2, "0")}`;
     });
   }, []);
 
+  const WeekDates = useMemo(() => {
+    if (grass.length > 0) {
+      return grass.map(({ date }) => {
+        const parsed = new Date(date);
+        if (Number.isNaN(parsed.getTime())) {
+          return date;
+        }
+
+        return `${(parsed.getMonth() + 1).toString().padStart(2, "0")}/${parsed.getDate().toString().padStart(2, "0")}`;
+      });
+    }
+
+    return fallbackWeekDates;
+  }, [fallbackWeekDates, grass]);
+
   const solvedData = useMemo(() => {
-    return [2, 3, 0, 4, 2, 5, 3];
-  }, []);
+    if (grass.length > 0) {
+      return grass.map(({ value }) => value ?? 0);
+    }
+
+    return Array.from({ length: 7 }, () => 0);
+  }, [grass]);
 
   const chartData = useMemo(() => {
     return {

--- a/modules/khj-user-interfaces/src/UserInfo.tsx
+++ b/modules/khj-user-interfaces/src/UserInfo.tsx
@@ -25,16 +25,14 @@ ChartJS.register(
 );
 
 interface UserInfoProps {
-  id: number;
   studentNumber: number;
   name: string;
   bojId: string;
   tier: string;
   totalSolved: number;
+  todaySolved?: number;
   accuracyRate: number;
   streak: number;
-  maxStreak: number;
-  flame: number;
   grass: {
     date: string;
     value: number;
@@ -47,6 +45,7 @@ export default function UserInfo({
   bojId,
   tier,
   totalSolved,
+  todaySolved,
   accuracyRate,
   streak,
   grass,
@@ -200,7 +199,7 @@ export default function UserInfo({
           <p>Total</p>
           <span>{totalSolved || 0}</span>
           <p>Today</p>
-          <span>{totalSolved || 0}</span>
+          <span>{todaySolved || 0}</span>
         </TotalBox>
         <Box>
           <p>정답률</p>


### PR DESCRIPTION
상세페이지 api 연동
#20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 학생 상세 페이지가 경로 인자(id)를 받아 동적으로 로드되도록 변경
  * 서버에서 학생 기본 정보와 최근 풀이(그래스)를 조회해 화면에 반영
  * 학생 카드/차트 컴포넌트가 외부 데이터(props)를 받아 이름, 학번, 레이트, 문제 수, 정확도, 연속 기록 및 기간별 그래프를 동적으로 표시하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->